### PR TITLE
ZIG-1039: Resolve rebuy percentage not filled and disabled.

### DIFF
--- a/src/components/TradingTerminal/DCAPanel/DCAPanel.js
+++ b/src/components/TradingTerminal/DCAPanel/DCAPanel.js
@@ -133,13 +133,14 @@ const DCAPanel = (props) => {
      */
     const fieldsDisabled = {};
     dcaAllIndexes.forEach((index) => {
-      const target = positionEntity ? positionEntity.reBuyTargets[Number(index)] : { done: false };
-
       let disabled = false;
-      if (target.done) {
-        disabled = true;
-      } else if (isReadOnly) {
-        disabled = true;
+      if (positionEntity) {
+        const target = positionEntity.reBuyTargets[Number(index)];
+        if (target.done || target.skipped) {
+          disabled = true;
+        } else if (isReadOnly) {
+          disabled = true;
+        }
       }
 
       fieldsDisabled[composeTargetPropertyName("rebuyPercentage", index)] = disabled;

--- a/src/services/tradeApiClient.types.js
+++ b/src/services/tradeApiClient.types.js
@@ -1131,7 +1131,7 @@ function positionRebuyTargetsTransforrm(rebuyTargets) {
     return {
       targetId: parseInt(rebuyTarget.targetId) || 0,
       triggerPercentage: parseFloat(rebuyTarget.triggerPercentage) || 0,
-      quantity: parseInt(rebuyTarget.quantity) || 0,
+      quantity: parseFloat(rebuyTarget.quantity) || 0,
       buying: rebuyTarget.buying || false,
       done: rebuyTarget.done || false,
       orderId: rebuyTarget.orderId || "",


### PR DESCRIPTION
The rebuy percentage was set to 0 when value was lower than 1 and editable when DCA was skipped, both problems are resolved in this PR.