### PR TITLE
ZIG-1046: Hide cancel on futures zignaly or CT provider owner.

### DIFF
--- a/src/components/Dashboard/PositionsTable/PositionsTable.js
+++ b/src/components/Dashboard/PositionsTable/PositionsTable.js
@@ -190,9 +190,11 @@ const PositionsTable = (props) => {
     let dataTable;
 
     const excludeCancelAction = () => {
+      const isFutures =
+        storeSettings.selectedExchange.exchangeType.toLocaleLowerCase() === "futures";
       const isZignaly = storeSettings.selectedExchange.exchangeName.toLowerCase() === "zignaly";
 
-      return isZignaly;
+      return isZignaly && isFutures;
     };
 
     if (type === "closed") {


### PR DESCRIPTION
Simplify the position cancel button display rule to:

1. Hide when exchange is type=futures and Zignaly.
2. Hide when the logged in user is the owner of the copy trader service of a given position.
3. Show in any other circumstances.