### PR TITLE
ZIG-1257: Use post submission method when JS disabled / not ready

### DIFF
--- a/src/components/ConnectExchangeView/ExchangeAccountAdd/ExchangeAccountAdd.js
+++ b/src/components/ConnectExchangeView/ExchangeAccountAdd/ExchangeAccountAdd.js
@@ -151,7 +151,7 @@ const ExchangeAccountAdd = ({ demo }) => {
   };
 
   return (
-    <form className="exchangeAccountAdd">
+    <form className="exchangeAccountAdd" method="post">
       {!selectedExchange ? (
         <Box className="loadProgress" display="flex" flexDirection="row" justifyContent="center">
           <CircularProgress disableShrink />

--- a/src/components/ConnectExchangeView/ExchangeAccountBalanceManagement/Withdraw/Withdraw.js
+++ b/src/components/ConnectExchangeView/ExchangeAccountBalanceManagement/Withdraw/Withdraw.js
@@ -152,7 +152,7 @@ const Withdraw = () => {
                   />
                 </Box>
                 <Box className="networkColumn">
-                  <form noValidate onSubmit={handleSubmit(onSubmit)}>
+                  <form noValidate method="post" onSubmit={handleSubmit(onSubmit)}>
                     <NetworksToggleGroup
                       networks={selectedAsset.networks.map((n) => n.name)}
                       selectedNetwork={selectedNetwork.name}

--- a/src/components/ConnectExchangeView/ExchangeAccountConnect/ExchangeAccountConnect.js
+++ b/src/components/ConnectExchangeView/ExchangeAccountConnect/ExchangeAccountConnect.js
@@ -142,7 +142,7 @@ const ExchangeAccountConnect = () => {
   }
 
   return (
-    <form className="exchangeAccountConnect" onSubmit={handleSubmit(submitForm)}>
+    <form className="exchangeAccountConnect" method="post" onSubmit={handleSubmit(submitForm)}>
       <Box className="step1">
         <Typography className="body1 bold" variant="h3">
           <FormattedMessage id="accounts.exchange.choose" />

--- a/src/components/ConnectExchangeView/ExchangeAccountSettings/ExchangeAccountSettings.js
+++ b/src/components/ConnectExchangeView/ExchangeAccountSettings/ExchangeAccountSettings.js
@@ -149,7 +149,7 @@ const ExchangeAccountSettings = () => {
     accountExchange && Boolean(accountExchange.requiredAuthFields.find((f) => dirtyFields[f]));
 
   return (
-    <form className="exchangeAccountSettings">
+    <form className="exchangeAccountSettings" method="post">
       {loading ? (
         <Box
           alignItems="center"

--- a/src/components/Forms/EditProfileForm/EditProfileForm.js
+++ b/src/components/Forms/EditProfileForm/EditProfileForm.js
@@ -293,7 +293,7 @@ const CopyTraderEditProfileForm = ({ provider }) => {
 
   return (
     <Box bgcolor="grid.content" className="formWrapper">
-      <form onSubmit={handleSubmit(onSubmit)}>
+      <form method="post" onSubmit={handleSubmit(onSubmit)}>
         <Box
           alignItems="flex-start"
           className="editProfileForm"

--- a/src/components/Forms/ForgotPasswordForm/ForgotPasswordForm.js
+++ b/src/components/Forms/ForgotPasswordForm/ForgotPasswordForm.js
@@ -56,7 +56,7 @@ const ForgotPasswordForm = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form method="post" onSubmit={handleSubmit(onSubmit)}>
       <Box
         alignItems="center"
         className="forgotPasswordForm"

--- a/src/components/Forms/LoginForm/LoginForm.js
+++ b/src/components/Forms/LoginForm/LoginForm.js
@@ -98,7 +98,7 @@ const LoginForm = () => {
       <Modal onClose={() => showTwoFAModal(false)} persist={false} size="small" state={twoFAModal}>
         <TwoFAForm data={loginResponse} onSuccess={onSuccess} />
       </Modal>
-      <form id="loginForm" onSubmit={handleSubmit(onSubmit)}>
+      <form id="loginForm" method="post" onSubmit={handleSubmit(onSubmit)}>
         <Box
           alignItems="center"
           className="loginForm"

--- a/src/components/Forms/ResetPasswordForm/ResetPasswordForm.js
+++ b/src/components/Forms/ResetPasswordForm/ResetPasswordForm.js
@@ -135,7 +135,7 @@ const ResetPasswordForm = ({ token, setVerified }) => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form method="post" onSubmit={handleSubmit(onSubmit)}>
       <Box
         alignItems="center"
         className="resetPasswordForm"

--- a/src/components/Forms/SignupForm/SignupForm.js
+++ b/src/components/Forms/SignupForm/SignupForm.js
@@ -62,7 +62,7 @@ const SignupForm = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form method="post" onSubmit={handleSubmit(onSubmit)}>
       <Box
         alignItems="center"
         className="signupForm"

--- a/src/components/SettingsView/SecuritySettings/Enable2FA/Enable2FA.js
+++ b/src/components/SettingsView/SecuritySettings/Enable2FA/Enable2FA.js
@@ -112,7 +112,7 @@ const Enable2FA = () => {
           <CircularProgress disableShrink />
         </Box>
       ) : (
-        <form onSubmit={handleSubmit(submitCode)}>
+        <form method="post" onSubmit={handleSubmit(submitCode)}>
           {!twoFAEnabled && (
             <>
               <Typography className="bold" variant="body1">

--- a/src/components/SettingsView/SecuritySettings/UpdatePassword/UpdatePassword.js
+++ b/src/components/SettingsView/SecuritySettings/UpdatePassword/UpdatePassword.js
@@ -74,7 +74,7 @@ const UpdatePassword = () => {
   };
 
   return (
-    <form className="updatePassword" onSubmit={handleSubmit(submitPassword)}>
+    <form className="updatePassword" method="post" onSubmit={handleSubmit(submitPassword)}>
       <Box className="inputBox" display="flex" flexDirection="column" width={1}>
         <Box className="passwordBox" display="flex" width={1}>
           <PasswordInput

--- a/src/components/TradingTerminal/StrategyForm/StrategyForm.js
+++ b/src/components/TradingTerminal/StrategyForm/StrategyForm.js
@@ -546,7 +546,7 @@ const StrategyForm = (props) => {
 
   return (
     <Box bgcolor="grid.content" className="strategyForm" textAlign="center">
-      <form onSubmit={handleSubmit(onSubmit)}>
+      <form method="post" onSubmit={handleSubmit(onSubmit)}>
         {isPositionView ? (
           <SidebarEditPanels
             currentSymbolData={currentSymbolData}


### PR DESCRIPTION
When JS is disabled and for any reason a SSR form is able to be submitted in webapp2 we should avoid that submitted data is revealed in the URL for reasons explained at https://support.google.com/adsense/answer/6156630?hl=en Therefore this PR changes the default form method to "post".