### PR TITLE
fix: ZIG-1260 Reload on version update should be timeout execution

### DIFF
--- a/src/hooks/useAppUpdatesCheck.js
+++ b/src/hooks/useAppUpdatesCheck.js
@@ -53,7 +53,7 @@ const useAppUpdatesCheck = (enableInterval = true) => {
 
     // Redux persist takes few milliseconds since update is notified and
     // persisted to local storage so refresh need to wait a bit.
-    setInterval(() => {
+    setTimeout(() => {
       location.reload();
     }, 300);
   };


### PR DESCRIPTION
@cwagner22 - Here is the patch for the issue you experienced with the version update reload, indeed, this should be a setTimeout. Thanks for report!