### PR TITLE
fix: Revert tp/sl percentage validation

### DIFF
--- a/src/components/TradingTerminal/StopLossPanel/StopLossPanel.js
+++ b/src/components/TradingTerminal/StopLossPanel/StopLossPanel.js
@@ -41,8 +41,7 @@ const StopLossPanel = (props) => {
   const { clearErrors, errors, getValues, register, setValue, watch, trigger, control } =
     useFormContext();
   const { lessThan } = useValidation();
-  const { getEntryPrice, getProfitPercentage, getEntrySizeQuote } =
-    usePositionEntry(positionEntity);
+  const { getEntryPrice, getEntrySizeQuote } = usePositionEntry(positionEntity);
   const entrySizeQuote = getEntrySizeQuote();
   const { validateSellAmount } = usePositionSizeHandlers(symbolData);
 
@@ -100,19 +99,20 @@ const StopLossPanel = (props) => {
   function validateStopLossPercentageLimits() {
     const draftPosition = getValues();
     const stopLossPercentage = parseFloat(draftPosition.stopLossPercentage);
-    const profitPercentage =
-      entryType.toUpperCase() === "SHORT" ? -getProfitPercentage() : getProfitPercentage();
+    // const profitPercentage =
+    //   entryType.toUpperCase() === "SHORT" ? -getProfitPercentage() : getProfitPercentage();
+    let valid = true;
 
-    let valid = lessThan(
-      stopLossPercentage,
-      profitPercentage,
-      entryType,
-      "terminal.stoploss.valid.percentage",
-      { value: format2Dec(profitPercentage) },
-    );
+    if (!positionEntity) {
+      // Check sign when creating a position.
+      valid = lessThan(stopLossPercentage, 0, entryType, "terminal.stoploss.valid.percentage", {
+        value: 0,
+      });
+    }
 
     if (valid === true && entrySizeQuote && stopLossPercentage) {
       const unitsSold = (entrySizeQuote * (100 + stopLossPercentage)) / 100;
+      // @ts-ignore
       valid = validateSellAmount(unitsSold);
     }
 

--- a/src/components/TradingTerminal/TakeProfitPanel/TakeProfitPanel.js
+++ b/src/components/TradingTerminal/TakeProfitPanel/TakeProfitPanel.js
@@ -80,7 +80,7 @@ const TakeProfitPanel = (props) => {
     (providerService && providerService.providerId !== "1") ||
     (positionEntity && positionEntity.isCopyTrader);
 
-  const { getEntryPrice, getEntrySize, getProfitPercentage } = usePositionEntry(positionEntity);
+  const { getEntryPrice, getEntrySize } = usePositionEntry(positionEntity);
   const targetsDone = positionEntity ? positionEntity.takeProfitTargetsCountSuccess : 0;
   const isTargetLocked = positionEntity ? cardinality === targetsDone : false;
   const disableRemoveAction = isReadOnly || isTargetLocked;
@@ -348,14 +348,12 @@ const TakeProfitPanel = (props) => {
    * @returns {boolean|string} true if validation pass, error message otherwise.
    */
   const validateTargetPricePercentage = (value) => {
-    const profitPercentage = getProfitPercentage();
-
     let valid = greaterThan(
       parseFloat(value),
-      profitPercentage,
+      0,
       entryType,
       "terminal.takeprofit.valid.pricepercentage",
-      { value: format2Dec(profitPercentage) },
+      { value: 0 },
     );
     return valid;
   };

--- a/src/components/TradingTerminal/TrailingStopPanel/TrailingStopPanel.js
+++ b/src/components/TradingTerminal/TrailingStopPanel/TrailingStopPanel.js
@@ -56,8 +56,7 @@ const TrailingStopPanel = (props) => {
   const trailingStopPercentage = parseFloat(trailingStopPercentageRaw);
   const { validateTargetPriceLimits } = useSymbolLimitsValidate(symbolData);
   const { lessThan, greaterThan } = useValidation();
-  const { getEntryPrice, getEntrySizeQuote, getProfitPercentage } =
-    usePositionEntry(positionEntity);
+  const { getEntryPrice, getEntrySizeQuote } = usePositionEntry(positionEntity);
   const entrySizeQuote = getEntrySizeQuote();
   const isClosed = positionEntity ? positionEntity.closed : false;
   const entryType = positionEntity ? positionEntity.side : watch("entryType");
@@ -89,19 +88,19 @@ const TrailingStopPanel = (props) => {
    */
   const validatePercentage = (value) => {
     const stopLossPercentage = parseFloat(value);
-    const profitPercentage = getProfitPercentage();
 
-    let valid = greaterThan(
-      value,
-      profitPercentage,
-      entryType,
-      "terminal.trailingstop.valid.percentage",
-      { value: format2Dec(profitPercentage) },
-    );
+    let valid = true;
+    if (positionEntity) {
+      greaterThan(value, 0, entryType, "terminal.trailingstop.valid.percentage", {
+        value: 0,
+      });
+    }
+
     if (valid === true) {
       if (stopLossPercentage && entrySizeQuote) {
         const amountSoldTrigger = (entrySizeQuote * (100 + stopLossPercentage)) / 100;
         const amountSold = (amountSoldTrigger * (100 + trailingStopDistance)) / 100;
+        // @ts-ignore
         valid = validateSellAmount(amountSold);
       }
     }


### PR DESCRIPTION
Only check when creating a position, for the sign. It would be nice to check to use the price difference to avoid allowing tp/sl that would triiger right away.