### PR TITLE
fix: Avoid sending token in signup call

### DIFF
--- a/src/services/tradeApiClient.js
+++ b/src/services/tradeApiClient.js
@@ -505,7 +505,7 @@ class TradeApiClient {
    * @memberof TradeApiClient
    */
   async userRegister(payload) {
-    const responseData = await this.doRequest("/signup", payload, "POST");
+    const responseData = await this.doRequest("/signup", payload, "POST", 2, false);
 
     return userEntityResponseTransform(responseData);
   }


### PR DESCRIPTION
It seems sometimes the token is not cleared and cause a session expired error when registering. Also the user is still redirected to login?